### PR TITLE
Handle missing arguments

### DIFF
--- a/src/ip.py
+++ b/src/ip.py
@@ -532,6 +532,9 @@ def main(argv):
     af=4
     argv.pop(0)
 
+  if not argv:
+    return False
+
   if argv[0] == '-V':
     print "iproute2mac, v" + VERSION
     exit(0)


### PR DESCRIPTION
handle case where ip family is specified but no other arguments are provided.