### PR TITLE
list host route entry in ip route

### DIFF
--- a/src/ip.py
+++ b/src/ip.py
@@ -158,7 +158,7 @@ def do_route_list(af):
       flags  = ra[2]
       dev    = ra[3]
       target = re.sub('%[^ ]+/','/',target)
-      if flags.find('W') != -1 or flags.find('H') != -1:
+      if flags.find('W') != -1:
         continue
       if re.match("link.+",gw):
         print target + ' dev ' + dev + '  scope link'
@@ -169,7 +169,7 @@ def do_route_list(af):
       gw     = ra[1]
       flags  = ra[2]
       dev    = ra[5]
-      if flags.find('W') != -1 or flags.find('H') != -1:
+      if flags.find('W') != -1:
         continue
       if target == 'default':
         print 'default via ' + gw + ' dev ' + dev


### PR DESCRIPTION
In `man netstat`
```
H       RTF_HOST         Host entry (net otherwise)
```

On Linux, if I use `ip route`, I can get those host route entries, like `1.2.3.4 via 192.168.1.1 dev eth0`.
So I think iproute2mac should also list those entries.

Thanks.