### PR TITLE
fix: add execution folder to import path

### DIFF
--- a/src/ip.py
+++ b/src/ip.py
@@ -10,13 +10,15 @@
   Copyright (c) 2015 Bronislav Robenek <brona@robenek.me>
 """
 
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
 from iproute2mac import *
 import ipaddress
-import os
 import re
 import socket
 import subprocess
-import sys
 
 
 # Decode ifconfig output


### PR DESCRIPTION
without this, I get the following error:

/opt/homebrew/Cellar/iproute2mac/1.5.2/libexec master
❯ ls
.rwxr-xr-x 7.2k mike 13 Aug 13:17 bridge
.rwxr-xr-x  21k mike 13 Aug 13:17 ip
.rw-r--r-- 3.3k mike 13 Aug 13:17 iproute2mac.py

/opt/homebrew/Cellar/iproute2mac/1.5.2/libexec master
❯ ip route get 1.1.1.1
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/iproute2mac/1.5.2/libexec/ip", line 13, in <module>
    from iproute2mac import *
ModuleNotFoundError: No module named 'iproute2mac'
