### PR TITLE
Add Support for ip route show ADDRESS

### DIFF
--- a/src/ip.py
+++ b/src/ip.py
@@ -186,7 +186,7 @@ def do_route(argv, af, json_print, pretty_json):
         any_startswith(["show", "lst", "list"], argv[0]) and len(argv) == 1
     ):
         return do_route_list(af, json_print, pretty_json)
-    elif "get".startswith(argv[0]) and len(argv) == 2:
+    elif any_startswith(["show", "get"], argv[0]) and len(argv) == 2:
         argv.pop(0)
         return do_route_get(argv, af, json_print, pretty_json)
     elif "add".startswith(argv[0]) and len(argv) >= 3:

--- a/test/commands.sh
+++ b/test/commands.sh
@@ -54,6 +54,8 @@ $ip_cmd -6 -j route show | tee | perl -MJSON -e 'decode_json(<STDIN>)'
 
 $ip_cmd -j -p -6 route show | grep "fe80::/64"
 
+$ip_cmd -j route show default
+
 $ip_cmd ro sho
 
 $ip_cmd r s


### PR DESCRIPTION
On Ubuntu systems,
the `ip route show default` and `ip route get default` are very similar. The most important point is that they both work.

This aliases `show` and `get`

Before
======

```
$ ip --json -4 route show default
Usage: ip route list
       ip route get ADDRESS
...
```

After
=====

```
ip -json route show default
[{"dst":"default","dev":"en0","gateway":"192.168.1.1","flags":[],"uid":501,"cache":[]}]
```

ubuntu
======

```
# ip --json -4 route show
[
    {"dst":"default","gateway":"172.17.0.1","dev":"eth0","flags":[]},
    {"dst":"172.17.0.0/16","dev":"eth0","protocol":"kernel","scope":"link","prefsrc":"172.17.0.2","flags":[]}
]
# ip --json -4 route list
[
    {"dst":"default","gateway":"172.17.0.1","dev":"eth0","flags":[]},
    {"dst":"172.17.0.0/16","dev":"eth0","protocol":"kernel","scope":"link","prefsrc":"172.17.0.2","flags":[]}
]
# ip --json -4 route get default
Warning: /0 as prefix is invalid, only /32 (or none) is supported.
[
    {"type":"local","dst":"0.0.0.0","dev":"lo","prefsrc":"127.0.0.1","flags":[],"uid":0,"cache":["local"]}
]
# ip --json -4 route show default
[
    {"dst":"default","gateway":"172.17.0.1","dev":"eth0","flags":[]}
]
```

(I put json output on multiple lines to work better with github)