### PR TITLE
Fix return status for ip route -6 get default

### DIFF
--- a/src/ip.py
+++ b/src/ip.py
@@ -348,8 +348,10 @@ def do_route_get(argv, af, json_print, pretty_json):
         perror(res)
         return False
     if res.find("not in table") >= 0:
-        perror(res)
-        exit(1)
+        if json_print:
+            return json_dump([], pretty_json)
+        else:
+            return True
 
     res = dict(
         re.findall(


### PR DESCRIPTION
If there is no default for a ipv6 default route,
Ubuntu just returns an empty result.

So this change just mimics linux's `ip` behavior.

Before
======

```
$ ./src/ip.py -6 -json route get default
route: writing to routing socket: not in table
```

After
=====

```
$ ./src/ip.py -6 route get default
$ ./src/ip.py -6 -json route get default
[]
```
