### PR TITLE
Filter interfaces by address family in ip addr show

### DIFF
--- a/src/ip.py
+++ b/src/ip.py
@@ -125,6 +125,16 @@ def link_addr_show(
 
     links = parse_ifconfig(res, af, address)
 
+    if address and af in [4, 6]:
+        links = [
+            l
+            for l in links
+            if any(
+                a["family"] == ("inet" if af == 4 else "inet6")
+                for a in l.get("addr_info", [])
+            )
+        ]
+
     if json_print:
         return json_dump(links, pretty_json)
 


### PR DESCRIPTION
Address issue #73 where `ip -4 a` and `ip -6 a` should only show interfaces with the respective address type. Modified `src/ip.py` to filter the `links` list when an address family is specified for `ip addr show`. Verified the fix with reproduction scripts and ensured no regressions in `ip link show` or other output formats.

---
*PR created automatically by Jules for task [14776036769361419256](https://jules.google.com/task/14776036769361419256) started by @brona*